### PR TITLE
Add an ability to generate policy source format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,23 @@
 # sepolicy-expander
 
 Tool helps determinate what raw allow rules will be enabled using specific selinux policy m4 macro.
-Geneterated output is in CIL representation.
+Geneterated output is in CIL representation or in policy source (.te) format.
 
 ## Usage
+
+    ./sepolicy-expander.sh [ -c | -t [ -M ] ] <macro>
+    Options:
+      -c     generate CIL output - this is default
+      -t     generate standard policy source format (.te) allow rules
+      -M     generate complete module .te output
 
     ./sepolicy-expander.sh "NAME_OF_MACRO(SELINUX_DOMAIN)"
 
 ## Example
 
-    $ git clone git@github.com:wrabcak/sepolicy-expander.git
+    $ git clone https://github.com/wrabcak/sepolicy-expander.git
     $ cd sepolicy-expander
+
     $ ./sepolicy-expander.sh "apache_read_log(mysqld_t)"
     (allow mysqld_t httpd_log_t (dir (getattr search open)))
     (allow mysqld_t httpd_log_t (dir (ioctl read getattr lock search open)))
@@ -18,3 +25,12 @@ Geneterated output is in CIL representation.
     (allow mysqld_t httpd_log_t (lnk_file (read getattr)))
     (allow mysqld_t var_log_t (dir (getattr search open)))
     (allow mysqld_t var_t (dir (getattr search open)))
+
+    $ ./sepolicy-expander.sh -t "apache_read_log(mysqld_t)"
+    allow mysqld_t var_t:dir { getattr search open };
+    allow mysqld_t var_log_t:dir { getattr search open };
+    allow mysqld_t httpd_log_t:dir { getattr search open read lock ioctl };
+    allow mysqld_t httpd_log_t:dir { getattr search open };
+    allow mysqld_t httpd_log_t:file { open { getattr read ioctl lock } };
+    allow mysqld_t httpd_log_t:dir { getattr search open };
+    allow mysqld_t httpd_log_t:lnk_file { getattr read };

--- a/sepolicy-expander.sh
+++ b/sepolicy-expander.sh
@@ -1,39 +1,81 @@
 #!/bin/bash
 
-SELINUX_MACRO=$1
-
-if [ -z $SELINUX_MACRO ]
-then
-    exit 1
-fi
+function usage {
+    echo "Usage: $0 [ -c | -t [ -M ] ] <macro>"
+    echo "Options:
+  -c     generate CIL output - this is default
+  -t     generate standard policy source format (.te) allow rules
+  -M     generate complete module .te output
+"
+}
 
 function cleanup {
     rm -rf $TEMP_STORE
 }
 
-IFS="("
-set $1
-SELINUX_DOMAIN="${2::-1}"
+while getopts "chMt" opt; do
+    case $opt in
+        c) GENCIL=1
+           ;;
+        t) GENTE=1
+           ;;
+        M) GENTEMODULE=1
+           ;;
+        h) usage
+           exit 0
+           ;;
+        \?) usage
+           exit 1
+           ;;
+    esac
+done
+
+shift $((OPTIND-1))
+
+SELINUX_MACRO=$1
+
+if [ -z "$SELINUX_MACRO" ]
+then
+    exit 1
+fi
 
 TEMP_STORE="$(mktemp -d)"
 cd $TEMP_STORE
 
+IFS="("
+set $1
+SELINUX_DOMAIN="${2::-1}"
+
 echo -e "policy_module(expander, 1.0.0) \n" \
      "gen_require(\`\n" \
      "type $SELINUX_DOMAIN ; \n" \
-     "')" > $TEMP_STORE/expander.te
+     "')" > expander.te
 
-echo "$SELINUX_MACRO" >> $TEMP_STORE/expander.te
+echo "$SELINUX_MACRO" >> expander.te
 
-make -f /usr/share/selinux/devel/Makefile expander.pp &> /dev/null
-MAKE_RESULT=$?
+make -f /usr/share/selinux/devel/Makefile tmp/all_interfaces.conf &> /dev/null
 
-if [ $MAKE_RESULT -eq 2 ]
-then
-    cleanup
-    exit 2
-else
-    cat $TEMP_STORE/expander.pp | /usr/libexec/selinux/hll/pp > $TEMP_STORE/expander.cil 2> /dev/null
-    cat $TEMP_STORE/expander.cil | grep -v "cil_gen_require" | sort -u
-    cleanup
+if [ "$GENCIL" = "1" -o "x$GENTE" != "x1" ]; then
+
+    make -f /usr/share/selinux/devel/Makefile expander.pp &> /dev/null
+    MAKE_RESULT=$?
+
+    if [ $MAKE_RESULT -ne 2 ]
+    then
+        /usr/libexec/selinux/hll/pp < $TEMP_STORE/expander.pp > $TEMP_STORE/expander.cil 2> /dev/null
+        grep -v "cil_gen_require" $TEMP_STORE/expander.cil | sort -u
+    fi
 fi
+
+if [ "x$GENTE" = "x1" ]; then
+    m4 -D enable_mcs -D distro_redhat -D hide_broken_symptoms -D mls_num_sens=16 -D mls_num_cats=1024 -D mcs_num_cats=1024 -s /usr/share/selinux/devel/include/support/file_patterns.spt /usr/share/selinux/devel/include/support/ipc_patterns.spt /usr/share/selinux/devel/include/support/obj_perm_sets.spt /usr/share/selinux/devel/include/support/misc_patterns.spt /usr/share/selinux/devel/include/support/misc_macros.spt /usr/share/selinux/devel/include/support/all_perms.spt /usr/share/selinux/devel/include/support/mls_mcs_macros.spt /usr/share/selinux/devel/include/support/loadable_module.spt tmp/all_interfaces.conf expander.te > expander.tmp 2> /dev/null
+    if [ "x$GENTEMODULE" = "x1" ]; then
+       #    sed '/^#.*$/d;/^\s*$/d;/^\s*class .*/d;/^\s*category .*/d;s/^\s*//' expander.tmp
+        sed '/^#.*$/d;/^\s*$/d;/^\s*category .*/d;s/^\s*//' expander.tmp
+    else
+        grep  '^\s*allow' expander.tmp | sed 's/^\s*//'
+    fi
+fi
+
+cd - > /dev/null
+cleanup


### PR DESCRIPTION
Usage: ./sepolicy-expander.sh [ -c | -t [ -M ] ] <macro>

Options:
  -c     generate CIL output - this is default
  -t     generate standard policy source format (.te) allow rules
  -M     generate complete module .te output